### PR TITLE
improved map zooming and extents, initial keyboard controls

### DIFF
--- a/app/assets/javascripts/clip.js
+++ b/app/assets/javascripts/clip.js
@@ -23,14 +23,17 @@ function clipinit() {
 
   // mds is disabled to prevent scrollwheel
   //var mds = new OpenLayers.Control.MouseDefaults();
+  var zoomWheel = new OpenLayers.Control.Navigation( { zoomWheelEnabled: true } );
+  //var keyboard = new OpenLayers.Control.KeyboardDefaults({ observeElement: 'map' })
+
+  var mapResolutions = [0.12, 0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2, 2.5, 3, 4, 5, 6, 7, 8.5, 10, 14, 18]
 
   var iw = clip_image_width + 1000; // why the extra width and height?
   var ih = clip_image_height + 500;
   clipmap = new OpenLayers.Map('clipmap', {
-    controls: [new OpenLayers.Control.PanZoomBar()],
+    controls: [new OpenLayers.Control.PanZoomBar(), zoomWheel],
     maxExtent: new OpenLayers.Bounds(-1000, 0, iw, ih),
-    maxResolution: 'auto',
-    numZoomLevels: 9
+    resolutions: mapResolutions
   });
 
   var image = new OpenLayers.Layer.WMS(title,
@@ -38,12 +41,16 @@ function clipinit() {
             layers: 'basic',
             format: 'image/png',
             status: 'unwarped'
-          });
+          }, { transitionEffect: 'resize' });
 
   clipmap.addLayer(image);
   if (!clipmap.getCenter()) {
     clipmap.zoomToMaxExtent();
   }
+
+
+
+
   //if theres a file load it
   //else make a plain one
 

--- a/app/assets/javascripts/unwarped.js
+++ b/app/assets/javascripts/unwarped.js
@@ -118,7 +118,7 @@ function unwarped_init() {
 
 
           /* numeric keypad */
-          case 96: // 1
+          case 96: // 0
               changeZoom(1);
               break;
           case 97: // 1

--- a/app/assets/javascripts/unwarped.js
+++ b/app/assets/javascripts/unwarped.js
@@ -83,6 +83,11 @@ function unwarped_init() {
               break;
         */
 
+          case 173: // top row - (?)
+              changeZoom('out');
+              break;
+
+          /* numbers at top of keyboard */
           case 49: // 1
               changeZoom(1);
               break;
@@ -108,6 +113,39 @@ function unwarped_init() {
               changeZoom(8);
               break;
           case 57: // -
+              changeZoom(9);
+              break;
+
+
+          /* numeric keypad */
+          case 96: // 1
+              changeZoom(1);
+              break;
+          case 97: // 1
+              changeZoom(1);
+              break;
+          case 98: // -
+              changeZoom(2);
+              break;
+          case 99: // -
+              changeZoom(3);
+              break;
+          case 100: // -
+              changeZoom(4);
+              break;
+          case 101: // -
+              changeZoom(5);
+              break;
+          case 102: // -
+              changeZoom(6);
+              break;
+          case 103: // -
+              changeZoom(7);
+              break;
+          case 104: // -
+              changeZoom(8);
+              break;
+          case 105: // -
               changeZoom(9);
               break;
 

--- a/app/assets/javascripts/warp.js
+++ b/app/assets/javascripts/warp.js
@@ -17,11 +17,12 @@ var active_from_vectors;
 ///////////////////////////////////////////////////////////////////////////////////////////
 function init() {
 
+  var mapResolutions = [0.12, 0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2, 2.5, 3, 4, 5, 6, 7, 8.5, 10, 14, 18]
+
   from_map = new OpenLayers.Map('from_map', {
     controls: [new OpenLayers.Control.PanZoomBar()],
     maxExtent: new OpenLayers.Bounds(0, 0, image_width, image_height),
-    maxResolution: 'auto',
-    numZoomLevels: 20
+    resolutions: mapResolutions
   });
   //  from_map.addControl(new OpenLayers.Control.MousePosition());
 
@@ -149,8 +150,8 @@ function init() {
     saveDraggedMarker(feature);
   };
 
-  navig = new OpenLayers.Control.Navigation({title: "Move Around Map (m)", zoomWheelEnabled: false});
-  navigFrom = new OpenLayers.Control.Navigation({title: "Move Around Map (m)", zoomWheelEnabled: false});
+  navig = new OpenLayers.Control.Navigation({title: "Move Around Map (m)", zoomWheelEnabled: true});
+  navigFrom = new OpenLayers.Control.Navigation({title: "Move Around Map (m)", zoomWheelEnabled: true});
 
   to_panel.addControls([navig, dragMarker, drawFeatureTo]);
   to_map.addControl(to_panel);
@@ -159,8 +160,8 @@ function init() {
   from_map.addControl(from_panel);
 
   //we'll add generic navigation controls so we can zoom whilst addingd
-  to_map.addControl(new OpenLayers.Control.Navigation({zoomWheelEnabled: false}));
-  from_map.addControl(new OpenLayers.Control.Navigation({zoomWheelEnabled: false}));
+  to_map.addControl(new OpenLayers.Control.Navigation({zoomWheelEnabled: true}));
+  from_map.addControl(new OpenLayers.Control.Navigation({zoomWheelEnabled: true}));
 
   navig.activate();
   navigFrom.activate();

--- a/app/assets/javascripts/warped.js
+++ b/app/assets/javascripts/warped.js
@@ -9,7 +9,7 @@ function warpedinit() {
     OpenLayers.Util.onImageLoadErrorColor = "transparent";
 
     // disabling the zoomWheel
-    var zoomWheel = new OpenLayers.Control.Navigation( { zoomWheelEnabled: false } );
+    var zoomWheel = new OpenLayers.Control.Navigation( { zoomWheelEnabled: true } );
 
     var options_warped = {
         projection: new OpenLayers.Projection("EPSG:900913"),
@@ -46,7 +46,8 @@ function warpedinit() {
             status: 'warped'
         }, {
             TRANSPARENT: 'true',
-            reproject: 'true'
+            reproject: 'true',
+            transitionEffect: null // Per docs, "Using 'resize' on non-opaque layers can cause undesired visual effects."
         }, {
             gutter: 15,
             buffer: 0
@@ -61,8 +62,6 @@ function warpedinit() {
     warpedmap.addLayer(warped_wmslayer);
 
     clipmap_bounds_merc = warped_bounds.transform(warpedmap.displayProjection, warpedmap.projection);
-
-    warpedmap.zoomToExtent(clipmap_bounds_merc);
 
     warpedmap.events.register("zoomend", mapnik3, function () {
       if (this.map.getZoom() > 18 && this.visibility == true) {
@@ -89,6 +88,8 @@ function warpedinit() {
     window.addEventListener("resize", warped_updateSize);
     warped_updateSize();
 
+    // after expanding map area zoom in
+    warpedmap.zoomToExtent(clipmap_bounds_merc);
 
 }
 

--- a/app/views/layouts/mapdetail.html.erb
+++ b/app/views/layouts/mapdetail.html.erb
@@ -14,7 +14,6 @@
       var addthis_share = {templates: {twitter: '{{url}} (from @<%=APP_CONFIG['addthis_twitter_user']%>)'}};
       var addthis_config = {ui_click: true};
 
-
       jQuery(function() {
         jQuery("#wooTabs").tabs({selected:<%=@selected_tab||0 %>});
         jQuery("#wooTabs").bind("tabsselect", function(event, ui) {
@@ -52,6 +51,12 @@
           if (ui.panel.id == "Show") {
             if (typeof umap != 'undefined') {
               unwarped_updateSize();
+
+              // if the page was initially loaded on any tab over than Show the zoom extent needs to be reset
+              if (umapLoaded === false){
+                umap.zoomToMaxExtent();
+              }
+
             } else {
               presetContainer()
             }
@@ -99,6 +104,7 @@
       // PageLoad function
       // This function is called when  1. after calling $.historyInit(); 2. after calling $.historyLoad(); 3. after pushing "Go Back" button of a browser
       var tabSuffix = "_tab"; //suffix to be added to link to stop jumping
+      var umapLoaded = false;
       function pageload(hash) {
         if (hash) {
           // restore ajax loaded state
@@ -112,6 +118,9 @@
           jQuery.each(tab_divs, function( index, value ) {
             if (hash === value.id){
               select_tab_index = index;
+              if (value.id.indexOf('Show') != -1){
+                umapLoaded = true;
+              } 
             }
           });
           

--- a/app/views/layouts/mapdetail.html.erb
+++ b/app/views/layouts/mapdetail.html.erb
@@ -58,7 +58,7 @@
               }
 
             } else {
-              presetContainer()
+              presetContainer();
             }
           }
 
@@ -89,6 +89,9 @@
           if (ui.panel.id == "Activity_History") {
 
           }
+
+          // shift focus from tabs to span to prevent arrow keys from changing tabs
+          jQuery("#focusHolder").attr('tabindex',-1).focus();
 
         }); //end tabshow
 
@@ -142,6 +145,15 @@
           jQuery.historyLoad(hash);
         });
       });
+
+      // prevent browser from scrolling with arrow keys
+      window.addEventListener("keydown", function(e) {
+          // space and arrow keys
+          if([32, 37, 38, 39, 40].indexOf(e.keyCode) > -1) {
+              e.preventDefault();
+          }
+      }, false);
+
     </script>
     <%= csrf_meta_tags %>
     <%= yield :head %>
@@ -167,7 +179,7 @@
     <table id="map_table">
       <%= render :partial => 'maps/map_detail', :object => @map, :locals => {:variety => "detail"} %>
     </table>
-
+    <span id="focusHolder"> </span>
     <% @tabs = [{:name=>"show",:divname=>"Show", :label=>"Show", :path=>map_path},
       {:name=>"warp",:divname=>"Rectify", :label=>"Rectify", :path=>warp_map_path(:id => @map)},
       {:name=>"clip",:divname=>"Crop", :label=>"Crop", :path=>clip_map_path(:id => @map)},


### PR DESCRIPTION
Map view changes

Show tab:
- improved the initial map fit when (zoom extent) when loading the tab
- fixed the zoom extent bug that had existed when loading the page to a different initial tab ( https://github.com/nypl-spacetime/nypl-warper/issues/20 )
- improved zoom levels (more granularity between zoom levels when zoomed)
- improved transition between zooms (map tiles resize and then refresh instead of going white when zoomed)
- added shortcut keys:
   + and - for zooming in and out
   arrow keys for moving the map
   1-9 for immediate jumps to zoom levels
- (re)enabled mousezoom which now works better with the other zoom changes in place
- moved page scroll position down to make more space for the map 

Crop tab:
- applied new zoom levels
- improved transition between zooms (screen no longer blanks out when zooming)
- enabled mousewheel now that performance is better
- did not apply shortkeys for zooming 
	- currently short keys impact all active map tabs and as such generate multiple batches of tile requests which slow performance. i hope to submit a future PR that enables shortkeys in all tabs without negatively impacting performance. for now keyboard controls are limited to the Show tab.

Rectify tab:
- improved initial fit in the From map (map on left side)
- applied new zoom levels to the From map
- (re)enabled mouse zoom
	mousewheel is still a bit erratic in the To map (right side) but the From map (left side) is performing much better than it had been 
	and it seems better at this point to consistently enable the mousewheel across all tabs

Preview:
- improved initial zoom extent
- enabled zoom wheel (for consistency across tabs, behavior is unchanged since it was last enabled)
- noted a bug which I'll report seperately - the bounds of the preview window, which are determined by the clipmap_bounds_merc value, seem to be the bounds of the raw map, not the clipped map, causing zoomToMaxExtent on the Preview tab to be inprecise (framing is too wide) 
